### PR TITLE
Improve caching for css/js files in prod/dev

### DIFF
--- a/docker/build/assets/data/conf/nginx/framework-configs/symfony4.conf
+++ b/docker/build/assets/data/conf/nginx/framework-configs/symfony4.conf
@@ -64,8 +64,20 @@ server {
     include /data/conf/nginx/security-headers.d/*.conf;
   }
 
+  # Special treatment of webpack generated hashed files ((name).(hash)(.es5).js|css)
+  location ~* '[0-9a-z]+\.[0-9a-z]{8,20}(\.es5)?\.(js|css)$' {
+    expires 1y; # one year
+    log_not_found off;
+    gzip  on;
+    gzip_min_length 1024; # one kb
+    add_header Pragma public;
+    add_header Cache-Control "public";
+    # need to include the headers here, too, because "server" level headers will not be added again if we use a "add_header" statement in the location block
+    include /data/conf/nginx/security-headers.d/*.conf;
+  }
+
   location ~* \.(js|css)$ {
-    expires 1h;
+    expires -1;
     log_not_found off;
     gzip  on;
     gzip_min_length 1024; # one kb


### PR DESCRIPTION
Disables caching for dev generated files <file>.css/js and enables it for prod generated files <file>.<hash>.css/js

Dev build:
![image](https://user-images.githubusercontent.com/5726865/196382923-22304013-c401-4563-93af-c33b528d275d.png)

Prod build:
![image](https://user-images.githubusercontent.com/5726865/196383030-954198fb-997c-4bec-931c-c4020074c733.png)
